### PR TITLE
footer: musicoin -> Musicoin

### DIFF
--- a/src/shared/Footer/index.js
+++ b/src/shared/Footer/index.js
@@ -39,7 +39,7 @@ export const Footer = () => (
 				<NavTitle>About</NavTitle>
 				<NavItems>
 					<NavItem>
-						<NavLink to="/how-it-works">What is musicoin?</NavLink>
+						<NavLink to="/how-it-works">What is Musicoin?</NavLink>
 					</NavItem>
 					<NavItem>
 						<NavLink to="/team">Team</NavLink>


### PR DESCRIPTION
Since the page "What is musicoin?" links to has the title "What is Musicoin?" - switch `musicoin` to `Musicoin` on the footer.

<img width="193" alt="Musicoin_Project" src="https://user-images.githubusercontent.com/4966687/61772174-486c5800-adfa-11e9-8c6b-ab2027294b52.png">
