### PR TITLE
Add Smart App Banner for iOS Users

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=1080">
-	<meta name="apple-itunes-app" content="app-id=id1447230096">
+	<meta name="apple-itunes-app" content="app-id=1447230096">
 	<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
 	<link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/cookie/cookie.css" />
 	<!--

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=1080">
+	<meta name="apple-itunes-app" content="app-id=id1447230096">
 	<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
 	<link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/cookie/cookie.css" />
 	<!--


### PR DESCRIPTION
This:
```
<meta name="apple-itunes-app" content="app-id=1447230096">
```

Will show the "Smart App Banner" for installing, or running, the Musicoin app if accessed via Mobile Safari.

Example:
<img width="306" alt="image" src="https://user-images.githubusercontent.com/4966687/61815969-0e2fa480-ae54-11e9-913e-481fcec9afb4.png">